### PR TITLE
feat: resolve issues #1 #3 #6 #7 #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,46 @@ A GitHub dashboard inside Neovim — contribution heatmap, PR/issue activity, re
 
 ## Installation
 
-**From a local clone** (development):
+**lazy.nvim (deferred — recommended)**:
 ```lua
-{ dir = vim.fn.expand("~/code/gh_dashboard.nvim"), lazy = false }
+{
+  "AlexanderInnerbichler/gh_dashboard.nvim",
+  cmd  = { "GhDashboard", "GhWatchlist" },
+  keys = {
+    { "<leader>gh", "<cmd>GhDashboard<cr>", desc = "GitHub Dashboard" },
+    { "<leader>gw", "<cmd>GhWatchlist<cr>",  desc = "GitHub Watchlist" },
+  },
+  config = function()
+    require("gh_dashboard").setup()
+    require("gh_dashboard.reader").setup()
+    require("gh_dashboard.watchlist").setup()
+    require("gh_dashboard.user_watchlist").setup()
+  end,
+}
 ```
 
-**From GitHub**:
+**lazy.nvim (eager)**:
 ```lua
-{ "innerbichler/gh_dashboard.nvim", lazy = false }
+{ "AlexanderInnerbichler/gh_dashboard.nvim", lazy = false }
+```
+
+**From a local clone** (development):
+```lua
+{ dir = vim.fn.expand("~/gh_dashboard.nvim"), lazy = false, dev = true }
 ```
 
 ## Setup
 
-Call `setup()` after the plugin loads — e.g. in `after/plugin/gh_dashboard.lua`:
-
 ```lua
-require("gh_dashboard").setup()
+require("gh_dashboard").setup({
+  -- all keys are optional; shown values are defaults
+  cache_ttl         = 300,  -- seconds before dashboard cache is stale
+  poll_interval     = 60,   -- seconds between watchlist polls
+  notification_ttl  = 5,    -- seconds before a toast auto-dismisses
+  max_notifications = 3,    -- maximum simultaneous toasts
+  max_history       = 20,   -- maximum notification history entries
+  window_width      = 0.9,  -- window width as fraction of screen (0–1)
+})
 require("gh_dashboard.reader").setup()
 require("gh_dashboard.watchlist").setup()
 require("gh_dashboard.user_watchlist").setup()

--- a/lua/gh_dashboard/config.lua
+++ b/lua/gh_dashboard/config.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+local defaults = {
+  cache_ttl         = 300,   -- seconds before cached dashboard data is stale
+  poll_interval     = 60,    -- seconds between watchlist polls
+  notification_ttl  = 5,     -- seconds before a toast auto-dismisses
+  max_notifications = 3,     -- maximum simultaneous notification toasts
+  max_history       = 20,    -- maximum notification history entries
+  window_width      = 0.9,   -- dashboard/reader window width as fraction of screen
+}
+
+local _config = vim.deepcopy(defaults)
+
+function M.setup(opts)
+  _config = vim.tbl_deep_extend("force", defaults, opts or {})
+end
+
+function M.get()
+  return _config
+end
+
+return M

--- a/lua/gh_dashboard/dashboard/fetch.lua
+++ b/lua/gh_dashboard/dashboard/fetch.lua
@@ -112,14 +112,20 @@ local CONTRIB_QUERY = table.concat({
   "} } }",
 }, " ")
 
-function M.contributions(callback)
+local function contributions_attempt(attempts, callback)
   vim.system(
     { "gh", "api", "graphql", "-f", "query=" .. CONTRIB_QUERY },
     { text = true },
     function(result)
       vim.schedule(function()
         if result.code ~= 0 then
-          callback(result.stderr or "graphql error", nil)
+          if attempts < 2 then
+            vim.defer_fn(function()
+              contributions_attempt(attempts + 1, callback)
+            end, 2 ^ attempts * 1000)
+          else
+            callback(result.stderr or "graphql error", nil)
+          end
           return
         end
         local ok, decoded = pcall(vim.fn.json_decode, result.stdout)
@@ -144,6 +150,10 @@ function M.contributions(callback)
       end)
     end
   )
+end
+
+function M.contributions(callback)
+  contributions_attempt(0, callback)
 end
 
 function M.repos(callback)

--- a/lua/gh_dashboard/dashboard/fetch.lua
+++ b/lua/gh_dashboard/dashboard/fetch.lua
@@ -33,7 +33,7 @@ end
 -- ── fetch functions ────────────────────────────────────────────────────────
 
 function M.profile(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "api", "user", "--jq",
       "{login:.login,name:.name,bio:.bio,followers:.followers,following:.following,public_repos:.public_repos}" },
     callback
@@ -41,7 +41,7 @@ function M.profile(callback)
 end
 
 function M.prs(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "search", "prs", "--author", "@me", "--state", "open",
       "--json", "number,title,repository,url,createdAt,isDraft" },
     function(err, data)
@@ -63,7 +63,7 @@ function M.prs(callback)
 end
 
 function M.issues(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "search", "issues", "--assignee", "@me", "--state", "open",
       "--json", "number,title,repository,url,createdAt" },
     function(err, data)
@@ -84,7 +84,7 @@ function M.issues(callback)
 end
 
 function M.activity(login, callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "api", "/users/" .. login .. "/events",
       "--jq", "[.[] | {type,repo:.repo.name,created_at}] | .[0:20]" },
     function(err, data)
@@ -147,7 +147,7 @@ function M.contributions(callback)
 end
 
 function M.repos(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "repo", "list", "--limit", "10",
       "--json", "name,nameWithOwner,url,description,primaryLanguage,stargazerCount,isPrivate,pushedAt" },
     function(err, data)
@@ -171,7 +171,7 @@ function M.repos(callback)
 end
 
 function M.org_repos(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "api", "/user/orgs", "--paginate" },
     function(err, orgs)
       if err or not orgs or #orgs == 0 then
@@ -182,7 +182,7 @@ function M.org_repos(callback)
       local all_repos = {}
       local any_err
       for _, org in ipairs(orgs) do
-        gh.run(
+        gh.run_with_retry(
           { "gh", "repo", "list", org.login, "--limit", "10",
             "--json", "name,nameWithOwner,url,primaryLanguage,stargazerCount,isPrivate,pushedAt" },
           function(ferr, repos)
@@ -216,7 +216,7 @@ function M.org_repos(callback)
 end
 
 function M.team_activity(callback)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "api", "/user/orgs", "--paginate" },
     function(err, orgs)
       if err then callback(err, nil) return end
@@ -225,7 +225,7 @@ function M.team_activity(callback)
       local all_events = {}
       local last_err
       for _, org in ipairs(orgs) do
-        gh.run(
+        gh.run_with_retry(
           { "gh", "api", "/orgs/" .. org.login .. "/events",
             "--jq", "[.[] | {type, actor: .actor.login, repo: .repo.name, created_at, pr_number: .payload.pull_request.number, issue_number: .payload.issue.number}]" },
           function(ferr, events)
@@ -263,7 +263,7 @@ function M.watched_users_activity(callback)
   local all_events = {}
   local last_err
   for _, username in ipairs(users) do
-    gh.run(
+    gh.run_with_retry(
       { "gh", "api", "/users/" .. username .. "/events",
         "--jq", "[.[] | {type, actor: .actor.login, repo: .repo.name, created_at, pr_number: .payload.pull_request.number, issue_number: .payload.issue.number}] | .[0:20]" },
       function(ferr, events)

--- a/lua/gh_dashboard/gh.lua
+++ b/lua/gh_dashboard/gh.lua
@@ -20,4 +20,19 @@ function M.run(args, callback)
   end)
 end
 
+--- Run a gh CLI command with up to 2 retries on failure (exponential backoff: 1s, 2s).
+--- callback(err, data): same contract as M.run.
+function M.run_with_retry(args, callback, attempts)
+  attempts = attempts or 0
+  M.run(args, function(err, data)
+    if err and attempts < 2 then
+      vim.defer_fn(function()
+        M.run_with_retry(args, callback, attempts + 1)
+      end, 2 ^ attempts * 1000)
+    else
+      callback(err, data)
+    end
+  end)
+end
+
 return M

--- a/lua/gh_dashboard/init.lua
+++ b/lua/gh_dashboard/init.lua
@@ -1,12 +1,9 @@
 local M = {}
+local config     = require("gh_dashboard.config")
 local heatmap    = require("gh_dashboard.heatmap")
 local highlights = require("gh_dashboard.highlights")
 local fetch      = require("gh_dashboard.dashboard.fetch")
 local render     = require("gh_dashboard.dashboard.render")
-
--- ── constants ──────────────────────────────────────────────────────────────
-
-local CACHE_TTL = 300  -- 5 minutes
 
 -- ── state ──────────────────────────────────────────────────────────────────
 
@@ -79,12 +76,25 @@ local function fetch_and_render()
   state.is_loading = true
   apply_render()
 
-  local pending   = 0
-  local any_error = false
+  local pending    = 0
+  local any_error  = false
+  local timed_out  = false
+  local timer      = vim.uv.new_timer()
+
+  timer:start(30000, 0, vim.schedule_wrap(function()
+    if timed_out then return end
+    timed_out = true
+    timer:close()
+    state.is_loading = false
+    apply_render()
+  end))
+
   local function done(had_err)
+    if timed_out then return end
     if had_err then any_error = true end
     pending = pending - 1
     if pending == 0 then
+      timer:close()
       state.is_loading = false
       if not any_error then write_cache(state.data) end
       apply_render()
@@ -183,8 +193,8 @@ local function open_win()
   end
 
   local ui     = vim.api.nvim_list_uis()[1] or { width = 180, height = 50 }
-  local width  = math.floor(ui.width  * 0.90)
-  local height = math.floor(ui.height * 0.90)
+  local width  = math.floor(ui.width  * config.get().window_width)
+  local height = math.floor(ui.height * config.get().window_width)
   local row    = math.floor((ui.height - height) / 2)
   local col    = math.floor((ui.width  - width)  / 2)
 
@@ -278,7 +288,7 @@ M.toggle = function()
   end
 
   state.data     = read_cache()
-  state.is_stale = cache_age_seconds() >= CACHE_TTL
+  state.is_stale = cache_age_seconds() >= config.get().cache_ttl
 
   open_win()
 
@@ -290,7 +300,8 @@ M.toggle = function()
   end
 end
 
-M.setup = function()
+M.setup = function(opts)
+  config.setup(opts)
   vim.fn.mkdir(vim.fn.expand("~/.cache/nvim"), "p")
   highlights.setup()
 end

--- a/lua/gh_dashboard/init.lua
+++ b/lua/gh_dashboard/init.lua
@@ -194,7 +194,7 @@ local function open_win()
 
   local ui     = vim.api.nvim_list_uis()[1] or { width = 180, height = 50 }
   local width  = math.floor(ui.width  * config.get().window_width)
-  local height = math.floor(ui.height * config.get().window_width)
+  local height = math.floor(ui.height * 0.90)
   local row    = math.floor((ui.height - height) / 2)
   local col    = math.floor((ui.width  - width)  / 2)
 

--- a/lua/gh_dashboard/reader/init.lua
+++ b/lua/gh_dashboard/reader/init.lua
@@ -248,7 +248,7 @@ function M.open_input(hint, on_submit)
     border     = "rounded",
     title      = " " .. hint .. " ",
     title_pos  = "center",
-    footer     = " <C-s> submit  ·  <Esc><Esc> cancel ",
+    footer     = " <C-s> submit  ·  q / <Esc><Esc> cancel ",
     footer_pos = "center",
   })
   vim.wo[state.input_win].number         = false
@@ -271,9 +271,10 @@ function M.open_input(hint, on_submit)
   local function imap(mode, lhs, fn)
     vim.keymap.set(mode, lhs, fn, { buffer = state.input_buf, nowait = true, silent = true })
   end
-  imap("n", "<C-s>",     do_submit)
-  imap("i", "<C-s>",     do_submit)
+  imap("n", "<C-s>",      do_submit)
+  imap("i", "<C-s>",      do_submit)
   imap("n", "<Esc><Esc>", close_input)
+  imap("n", "q",          close_input)
 
   vim.api.nvim_create_autocmd("BufWipeout", {
     buffer   = state.input_buf,

--- a/lua/gh_dashboard/reader/init.lua
+++ b/lua/gh_dashboard/reader/init.lua
@@ -228,7 +228,7 @@ function M.open_input(hint, on_submit)
   state.input_buf = vim.api.nvim_create_buf(false, true)
   vim.bo[state.input_buf].buftype   = "nofile"
   vim.bo[state.input_buf].bufhidden = "wipe"
-  vim.bo[state.input_buf].filetype  = "markdown"
+  vim.bo[state.input_buf].filetype  = "text"
 
   vim.api.nvim_buf_set_lines(state.input_buf, 0, -1, false, { "", "" })
 

--- a/lua/gh_dashboard/reader/init.lua
+++ b/lua/gh_dashboard/reader/init.lua
@@ -365,35 +365,35 @@ M.open_diff = function(item)
   write_buf({ "", "  Loading diff…" }, {})
 
   vim.keymap.set("v", "c", function()
+    vim.cmd("normal! \27")  -- exit visual mode first so '< '> are committed
     local end_ln = vim.fn.getpos("'>")[2] - 1
     local info   = state.diff_line_map[end_ln]
     if not info then
-      vim.cmd("normal! \27")
       vim.notify("Cannot comment on this line", vim.log.levels.INFO)
       return
     end
     if not state.diff_head_sha or state.diff_head_sha == "" then
-      vim.cmd("normal! \27")
       vim.notify("Still loading, please try again", vim.log.levels.INFO)
       return
     end
-    vim.cmd("normal! \27")
-    M.open_input("Review comment  |  <C-s> submit  ·  <Esc><Esc> cancel", function(body)
-      if body == "" then
-        vim.notify("Comment cannot be empty", vim.log.levels.WARN)
-        return
-      end
-      fetch.post_review_comment(
-        state.diff_item.number, state.diff_item.repo,
-        state.diff_head_sha, info.path, info.line, info.side,
-        body, function(err)
-          if err then
-            vim.notify("Failed: " .. err:gsub("[\n\r]", " "), vim.log.levels.ERROR)
-          else
-            vim.notify("Review comment posted", vim.log.levels.INFO)
-          end
+    vim.schedule(function()  -- defer so startinsert runs after mode transition settles
+      M.open_input("Review comment  |  <C-s> submit  ·  <Esc><Esc> cancel", function(body)
+        if body == "" then
+          vim.notify("Comment cannot be empty", vim.log.levels.WARN)
+          return
         end
-      )
+        fetch.post_review_comment(
+          state.diff_item.number, state.diff_item.repo,
+          state.diff_head_sha, info.path, info.line, info.side,
+          body, function(err)
+            if err then
+              vim.notify("Failed: " .. err:gsub("[\n\r]", " "), vim.log.levels.ERROR)
+            else
+              vim.notify("Review comment posted", vim.log.levels.INFO)
+            end
+          end
+        )
+      end)
     end)
   end, { buffer = state.buf, nowait = true, silent = true })
   require("gh_dashboard.help").setup_keymap(state.buf, "diff")

--- a/lua/gh_dashboard/watchlist.lua
+++ b/lua/gh_dashboard/watchlist.lua
@@ -1,4 +1,5 @@
 local M = {}
+local config     = require("gh_dashboard.config")
 local gh         = require("gh_dashboard.gh")
 local highlights = require("gh_dashboard.highlights")
 
@@ -7,11 +8,7 @@ local highlights = require("gh_dashboard.highlights")
 local WATCHLIST_PATH = vim.fn.expand("~/.config/nvim/gh-watchlist.json")
 local NOTIF_WIDTH    = 60
 local NOTIF_HEIGHT   = 4
-local MAX_NOTIFS     = 3
-local MAX_HISTORY    = 20
-local NOTIF_TTL_MS   = 5000
 local POLL_DELAY_MS  = 5000
-local POLL_REPEAT_MS = 60000
 
 -- ── state ──────────────────────────────────────────────────────────────────
 
@@ -19,7 +16,7 @@ local state = {
   repos        = {},   -- list of { owner, repo, last_seen_id }
   poll_timer   = nil,
   notifs       = {},   -- list of { win, buf, timer, _repo, _ev }
-  history      = {},   -- list of { _repo, _ev } newest-first, max MAX_HISTORY
+  history      = {},   -- list of { _repo, _ev } newest-first
   manager_buf  = nil,
   manager_win  = nil,
 }
@@ -37,6 +34,14 @@ local function load_watchlist()
   local ok, data = pcall(vim.fn.json_decode, table.concat(lines, "\n"))
   if ok and type(data) == "table" and type(data.repos) == "table" then
     state.repos = data.repos
+    -- migrate legacy last_seen_id → seen_ids
+    for _, entry in ipairs(state.repos) do
+      if entry.last_seen_id and not entry.seen_ids then
+        entry.seen_ids    = { tostring(entry.last_seen_id) }
+        entry.last_seen_id = nil
+      end
+      if not entry.seen_ids then entry.seen_ids = {} end
+    end
   end
 end
 
@@ -151,7 +156,7 @@ local function show_notification(repo, ev)
   local ui  = vim.api.nvim_list_uis()[1] or { width = 180, height = 50 }
 
   -- evict oldest if at cap
-  if #state.notifs >= MAX_NOTIFS then
+  if #state.notifs >= config.get().max_notifications then
     local oldest = table.remove(state.notifs, 1)
     if oldest.timer then oldest.timer:stop() oldest.timer:close() end
     if oldest.win and vim.api.nvim_win_is_valid(oldest.win) then
@@ -217,7 +222,7 @@ local function show_notification(repo, ev)
   vim.keymap.set("n", "<Esc>", close_notif, { buffer = buf, nowait = true, silent = true })
 
   local t = vim.uv.new_timer()
-  t:start(NOTIF_TTL_MS, 0, vim.schedule_wrap(function()
+  t:start(config.get().notification_ttl * 1000, 0, vim.schedule_wrap(function()
     t:stop() t:close()
     close_notif()
   end))
@@ -226,13 +231,26 @@ local function show_notification(repo, ev)
 
   -- keep a history so open_latest works after the popup auto-dismisses
   table.insert(state.history, 1, { _repo = repo, _ev = ev })
-  if #state.history > MAX_HISTORY then table.remove(state.history) end
+  if #state.history > config.get().max_history then table.remove(state.history) end
 end
 
 -- ── polling ────────────────────────────────────────────────────────────────
 
+local function is_new(entry, ev_id)
+  for _, id in ipairs(entry.seen_ids or {}) do
+    if id == ev_id then return false end
+  end
+  return true
+end
+
+local function mark_seen(entry, ev_id)
+  entry.seen_ids = entry.seen_ids or {}
+  table.insert(entry.seen_ids, 1, ev_id)
+  if #entry.seen_ids > 50 then entry.seen_ids[51] = nil end
+end
+
 local function poll_repo(entry)
-  gh.run(
+  gh.run_with_retry(
     { "gh", "api",
       "repos/" .. entry.owner .. "/" .. entry.repo .. "/events",
       "--jq", "[.[] | {id,type,created_at,payload}] | .[0:10]" },
@@ -240,11 +258,13 @@ local function poll_repo(entry)
       if err or not events or type(events) ~= "table" or #events == 0 then return end
       local new_events = {}
       for _, ev in ipairs(events) do
-        if tostring(ev.id) == tostring(entry.last_seen_id) then break end
-        table.insert(new_events, ev)
+        local ev_id = tostring(ev.id)
+        if is_new(entry, ev_id) then
+          table.insert(new_events, ev)
+          mark_seen(entry, ev_id)
+        end
       end
       if #new_events > 0 then
-        entry.last_seen_id = tostring(events[1].id)
         save_watchlist()
         for _, ev in ipairs(new_events) do
           local ok, err = pcall(show_notification, entry.owner .. "/" .. entry.repo, ev)
@@ -269,7 +289,7 @@ local function seed_history()
         for _, ev in ipairs(events) do
           table.insert(state.history, { _repo = repo_key, _ev = ev })
         end
-        while #state.history > MAX_HISTORY do
+        while #state.history > config.get().max_history do
           table.remove(state.history)
         end
       end
@@ -613,7 +633,7 @@ M.setup = function()
   load_watchlist()
   seed_history()
   state.poll_timer = vim.uv.new_timer()
-  state.poll_timer:start(POLL_DELAY_MS, POLL_REPEAT_MS, vim.schedule_wrap(poll))
+  state.poll_timer:start(POLL_DELAY_MS, config.get().poll_interval * 1000, vim.schedule_wrap(poll))
   highlights.setup()
 end
 

--- a/lua/gh_dashboard/watchlist.lua
+++ b/lua/gh_dashboard/watchlist.lua
@@ -246,7 +246,7 @@ end
 local function mark_seen(entry, ev_id)
   entry.seen_ids = entry.seen_ids or {}
   table.insert(entry.seen_ids, 1, ev_id)
-  if #entry.seen_ids > 50 then entry.seen_ids[51] = nil end
+  if #entry.seen_ids > 50 then table.remove(entry.seen_ids) end
 end
 
 local function poll_repo(entry)

--- a/plugin/gh_dashboard.lua
+++ b/plugin/gh_dashboard.lua
@@ -1,4 +1,10 @@
 if vim.g.gh_dashboard_loaded then return end
 vim.g.gh_dashboard_loaded = true
--- keymaps and setup() are registered lazily via require("gh_dashboard").setup()
--- The plugin entry point is intentionally minimal; consumers call setup() themselves.
+
+vim.api.nvim_create_user_command("GhDashboard", function()
+  require("gh_dashboard").toggle()
+end, { desc = "Toggle GitHub Dashboard" })
+
+vim.api.nvim_create_user_command("GhWatchlist", function()
+  require("gh_dashboard.watchlist").toggle()
+end, { desc = "Toggle GitHub Watchlist manager" })


### PR DESCRIPTION
## Summary

- **#1 Config table**: New `config.lua` shared module with `cache_ttl`, `poll_interval`, `notification_ttl`, `max_notifications`, `max_history`, `window_width`; all modules read from `config.get()` at runtime
- **#3 Timeout guard**: 30-second `vim.uv.new_timer` in `fetch_and_render()` fan-out — renders partial data if any fetch stalls
- **#6 Retry with backoff**: `gh.run_with_retry()` with exponential backoff (1s, 2s), max 2 retries; all fetch calls upgraded
- **#7 Sliding window seen_ids**: Replaces single `last_seen_id` string with ordered list (≤50 entries, newest-first); migrates old watchlist entries on load
- **#8 Lazy loading**: `GhDashboard` + `GhWatchlist` user commands in `plugin/gh_dashboard.lua`; README updated with lazy.nvim `cmd`/`keys` deferred loading example and full config table docs

## Test plan

- [ ] Run `:GhDashboard` — dashboard opens, heatmap + PRs + activity load
- [ ] Run `:GhWatchlist` — watchlist manager opens; add a repo and verify polling fires
- [ ] Verify `require("gh_dashboard").setup({ cache_ttl = 60 })` overrides default; stale check fires at 60s
- [ ] Simulate a slow/failing `gh` call; confirm retry fires (check `:messages`) and timeout renders partial data after 30s
- [ ] Add a watched repo that has recent events; confirm new events appear in toasts; old events are not re-notified after restart (seen_ids persisted)